### PR TITLE
Fix operand type error.

### DIFF
--- a/progressmonitor/__init__.py
+++ b/progressmonitor/__init__.py
@@ -637,7 +637,7 @@ class TrackerBase(object):
 
     def with_estimated_seconds(self, e, clean=False):
         if not self.estimated_seconds == e:
-            self.estimated_seconds = e
+            self.estimated_seconds = int(e)
             if not clean:
                 self.dirty = True
         return self


### PR DESCRIPTION
Boto3 returns a Decimal object for the estimated_secconds attribute when loading the tracker by id, causing an operand type error when calculating the elapsed time.