### PR TITLE
Ensure conversions to integer seconds

### DIFF
--- a/progressmonitor/__init__.py
+++ b/progressmonitor/__init__.py
@@ -51,7 +51,7 @@ class TrackerState(object):
         else:
             delta = arrow.utcnow() - self.start_time
 
-        return delta.total_seconds()
+        return int(round(delta.total_seconds()))
 
     def remaining_time_in_seconds(self):
         if self.estimated_seconds:
@@ -420,13 +420,13 @@ class TrackerBase(object):
         if len(self.children):
             secs = 0
             for k in self.children:
-                tot = k.total_estimate
+                tot = int(k.total_estimate)
                 if self.has_parallel_children and tot > longest:
                     longest = tot
                 else:
                     secs = secs + tot
         else:
-            return self.estimated_seconds
+            return int(self.estimated_seconds)
 
         if self.has_parallel_children:
             return longest


### PR DESCRIPTION
Added conversions to integers for elapsed seconds, as DynamoDB can
convert fields in to the Decimal type, which won't mix in math
expressions that involve the float type. This was leading to
TypeErrors.